### PR TITLE
fix 0 index boolean bug

### DIFF
--- a/src/table/components/table-body.ts
+++ b/src/table/components/table-body.ts
@@ -127,12 +127,14 @@ export class TableBody<TDataRow extends TableRow>
       this.getCachedVirtualBounds();
     const columnIndex = this.columnLookup.getIndex(v.columnId);
     const isVisibleColumn =
-      columnIndex &&
+      columnIndex !== undefined &&
       leftColumnIndex <= columnIndex &&
       columnIndex <= rightColumnIndex;
     const rowIndex = this.sortedRowModel.getIndex(v.rowId);
     const isVisibleRow =
-      rowIndex && topRowIndex <= rowIndex && rowIndex <= bottomRowIndex;
+      rowIndex !== undefined &&
+      topRowIndex <= rowIndex &&
+      rowIndex <= bottomRowIndex;
     if (isVisibleColumn && isVisibleRow) {
       this.tableWorker.send({
         type: "CELL_SIZE",


### PR DESCRIPTION
Previously the boolean evaluation was considering a 0 index for column or row index to be falsy. This explicit undefined check works around that issue.