### PR TITLE
compute total table width using all columns

### DIFF
--- a/src/table/components/table-body.ts
+++ b/src/table/components/table-body.ts
@@ -123,19 +123,13 @@ export class TableBody<TDataRow extends TableRow>
   handleRecvSourceData = (v: TableSourceData) => {
     const cellData = this.cellDataStore.getCellData(v.rowId, v.columnId);
     cellData.setValue(v.data);
-    const { leftColumnIndex, rightColumnIndex, topRowIndex, bottomRowIndex } =
-      this.getCachedVirtualBounds();
-    const columnIndex = this.columnLookup.getIndex(v.columnId);
-    const isVisibleColumn =
-      columnIndex !== undefined &&
-      leftColumnIndex <= columnIndex &&
-      columnIndex <= rightColumnIndex;
+    const { topRowIndex, bottomRowIndex } = this.getCachedVirtualBounds();
     const rowIndex = this.sortedRowModel.getIndex(v.rowId);
     const isVisibleRow =
       rowIndex !== undefined &&
       topRowIndex <= rowIndex &&
       rowIndex <= bottomRowIndex;
-    if (isVisibleColumn && isVisibleRow) {
+    if (isVisibleRow) {
       this.tableWorker.send({
         type: "CELL_SIZE",
         payload: {


### PR DESCRIPTION
When computing the total table width we should use the content for all columns, not just the ones in the viewport. Otherwise, we risk showing an inaccurate horizontal scrollbar.