### PR TITLE
update hover state and cell composition

### DIFF
--- a/src/table/components/body/table-body-cell.ts
+++ b/src/table/components/body/table-body-cell.ts
@@ -1,0 +1,64 @@
+import { Padding } from "../../../types/table-cell-types";
+import { Dimensions } from "../../../utils/dimensions";
+import { TableData } from "../../../utils/table-data";
+import { TableCell } from "../table-cell";
+
+export class TableBodyCell extends TableCell {
+  private isHovered: boolean = false;
+
+  public bind({
+    x,
+    y,
+    data,
+    width,
+    height,
+    isHovered,
+  }: {
+    x: number;
+    y: number;
+    data: TableData<unknown>;
+    width: number;
+    height: number;
+    isHovered: boolean;
+  }): void {
+    super.bind({
+      x,
+      y,
+      data,
+      width,
+      height,
+    });
+    this.isHovered = isHovered;
+  }
+
+  public drawClipped(
+    ctx: CanvasRenderingContext2D,
+    clippedDimensions: Dimensions,
+    padding: Required<Padding>,
+  ): void {
+    const { x, textAlign } = this.getAlignment(clippedDimensions.w);
+
+    ctx.textAlign = textAlign;
+
+    const y = this.point.y + padding.top + clippedDimensions.h / 2;
+
+    ctx.fillText(this.data?.getDisplayableContent() ?? "NA", x, y);
+  }
+
+  public drawGlobal(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+
+    if (this.isHovered) {
+      ctx.fillStyle = "red";
+
+      ctx.fillRect(
+        this.point.x,
+        this.point.y,
+        this.dimensions.w,
+        this.dimensions.h,
+      );
+    }
+
+    ctx.restore();
+  }
+}

--- a/src/table/components/body/table-body.ts
+++ b/src/table/components/body/table-body.ts
@@ -3,29 +3,28 @@ import {
   TableConfig,
   TableRow,
   TableSourceData,
-} from "../../types/table-config";
-import { Dimensions } from "../../utils/dimensions";
-import { Camera } from "../../utils/camera";
-import { DrawCanvas } from "../../utils/draw-canvas";
-import { TableCell } from "./table-cell";
+} from "../../../types/table-config";
+import { Dimensions } from "../../../utils/dimensions";
+import { Camera } from "../../../utils/camera";
+import { DrawCanvas } from "../../../utils/draw-canvas";
 import { merge, Observable, Subscription } from "rxjs";
-import { ColumnSizeMap } from "../../utils/column-size-map";
+import { ColumnSizeMap } from "../../../utils/column-size-map";
 import {
   boundaryBinarySearchLeftOrTop,
   boundaryBinarySearchRightOrBottom,
   calculateTopAndBottomRowBounds,
-} from "../../utils/boundary-search";
-import { Axis } from "../../utils/axis";
-import { CellPool } from "../../utils/cell-pool";
-import { Closeable } from "../../utils/closeable";
-import { CellDataStore } from "../../utils/cell-data-store";
-import { TableData } from "../../utils/table-data";
-import { TableWorker } from "../table-worker";
-import { Point } from "../../utils/point";
-import { Mouse } from "../../utils/mouse";
-import { TableBodyOverlay } from "../table-body-overlay";
-import { SortedRowModel } from "../../utils/sorted-row-model";
-import { ColumnLookup } from "../../utils/column-lookup";
+} from "../../../utils/boundary-search";
+import { Axis } from "../../../utils/axis";
+import { CellPool } from "../../../utils/cell-pool";
+import { Closeable } from "../../../utils/closeable";
+import { CellDataStore } from "../../../utils/cell-data-store";
+import { TableData } from "../../../utils/table-data";
+import { TableWorker } from "../../table-worker";
+import { Point } from "../../../utils/point";
+import { Mouse } from "../../../utils/mouse";
+import { TableBodyOverlay } from "../../table-body-overlay";
+import { SortedRowModel } from "../../../utils/sorted-row-model";
+import { TableBodyCell } from "./table-body-cell";
 
 type VirtualBounds = {
   leftColumnIndex: number;
@@ -38,10 +37,10 @@ export class TableBody<TDataRow extends TableRow>
   implements Closeable
 {
   private canvasWrapperDiv: HTMLDivElement;
-  private cellPool: CellPool<TableCell>;
+  private cellPool: CellPool<TableBodyCell>;
   private sourceSubscription: Subscription;
   private columnResizeSubscription: Subscription;
-  private hoveredRowId: string | undefined;
+  private hoveredRowIndex: number | undefined;
   private _prevMousePoint: Point = new Point();
   private overlay: TableBodyOverlay;
   private _cachedVirtualBounds: VirtualBounds | undefined;
@@ -55,7 +54,6 @@ export class TableBody<TDataRow extends TableRow>
     private readonly mouse: Mouse,
     private readonly sortedRowModel: SortedRowModel<TDataRow>,
     private readonly cellDataStore: CellDataStore<TDataRow>,
-    private readonly columnLookup: ColumnLookup<TDataRow>,
     dimensions: Dimensions,
   ) {
     super(dimensions);
@@ -78,7 +76,7 @@ export class TableBody<TDataRow extends TableRow>
       rowHeight: this.config.style.body.row.height,
       minColumnWidth: this.columnSizes.getMinColumnWidth(),
       cellFactory: () => {
-        return new TableCell(this.config.style.body.cell);
+        return new TableBodyCell(this.config.style.body.cell);
       },
     });
 
@@ -111,7 +109,7 @@ export class TableBody<TDataRow extends TableRow>
       this.mouseMove,
       new Point(0, -1 * this.config.style.header.row.height),
     );
-    this.mouse.onMouseLost(() => this.overlay.hide());
+    this.mouse.onMouseLost(this.mouseLost);
 
     this.requestRedraw();
   }
@@ -147,24 +145,49 @@ export class TableBody<TDataRow extends TableRow>
     this.requestRedraw();
   };
 
+  mouseLost = () => {
+    this.overlay.hide();
+    this.hoveredRowIndex = undefined;
+    this.requestRedraw();
+  };
+
   mouseMove = (point: Point): void => {
     this._prevMousePoint.copy(point);
-    if (point.y < 0) {
+    this.updateHoveredRowState(point);
+    this.requestRedraw();
+  };
+
+  private updateHoveredRowState(mousePoint: Point): void {
+    if (mousePoint.y < 0) {
       this.overlay.hide();
+      this.hoveredRowIndex = undefined;
       return;
     }
-    const worldY = point.y + this.camera.y;
+    const rowIndex = this.getHoveredRowIndexFromMousePoint(mousePoint);
+    if (rowIndex === undefined) {
+      this.overlay.hide();
+      this.hoveredRowIndex = undefined;
+      return;
+    }
+
+    const rowTopY =
+      rowIndex * this.config.style.body.row.height - this.camera.y;
+    this.overlay.drawAtPoint(rowTopY);
+
+    this.hoveredRowIndex = rowIndex;
+  }
+
+  private getHoveredRowIndexFromMousePoint(
+    mousePoint: Point,
+  ): number | undefined {
+    const worldY = mousePoint.y + this.camera.y;
     const rowHeight = this.config.style.body.row.height;
     const rowIndex = Math.floor(worldY / rowHeight);
-    let nextHoveredRowId: string | undefined;
     if (rowIndex >= 0 && rowIndex < this.sortedRowModel.length) {
-      nextHoveredRowId = this.sortedRowModel.getRow(rowIndex).rowId;
-      const rowTopY = rowIndex * rowHeight - this.camera.y;
-      this.overlay.drawAtPoint(rowTopY);
+      return rowIndex;
     }
-    if (nextHoveredRowId === this.hoveredRowId) return;
-    this.hoveredRowId = nextHoveredRowId;
-  };
+    return undefined;
+  }
 
   private getColumnResizeObservables(
     columns: Array<TableColumnDef<TDataRow>>,
@@ -260,6 +283,7 @@ export class TableBody<TDataRow extends TableRow>
             column.columnId,
             tableDataFactoryWithPlaceholder(column, row),
           ),
+          isHovered: this.hoveredRowIndex === r,
         });
         cell.draw(ctx);
       }

--- a/src/table/components/header/header-filter.ts
+++ b/src/table/components/header/header-filter.ts
@@ -1,4 +1,4 @@
-import { Drawable } from "../../utils/drawable";
+import { Drawable } from "../../../utils/drawable";
 
 const HEADER_FILTER_WIDTH = 6;
 const HEADER_FILTER_SPACING = 2;

--- a/src/table/components/header/header-resizer.ts
+++ b/src/table/components/header/header-resizer.ts
@@ -1,7 +1,7 @@
-import { BoundingBox } from "../../utils/bounding-box";
-import { Dimensions } from "../../utils/dimensions";
-import { Point } from "../../utils/point";
-import { WorldObject } from "../../utils/world-object";
+import { BoundingBox } from "../../../utils/bounding-box";
+import { Dimensions } from "../../../utils/dimensions";
+import { Point } from "../../../utils/point";
+import { WorldObject } from "../../../utils/world-object";
 
 export const RESIZER_WIDTH = 1;
 export const RESIZER_HOVER_BUFFER_LEFT = 10;

--- a/src/table/components/header/table-header-cell.ts
+++ b/src/table/components/header/table-header-cell.ts
@@ -1,14 +1,14 @@
-import { TableCellStyles } from "../../types/table-cell-types";
+import { Padding, TableCellStyles } from "../../../types/table-cell-types";
 import {
   DEFAULT_FONT_STRING,
   DEFAULT_TEXT_COLOR,
-} from "../../utils/cell-style-defaults";
-import { getPadding } from "../../utils/padding-utils";
-import { Point } from "../../utils/point";
-import { TableData } from "../../utils/table-data";
+} from "../../../utils/cell-style-defaults";
+import { Point } from "../../../utils/point";
+import { TableData } from "../../../utils/table-data";
 import { HeaderFilter } from "./header-filter";
 import { HeaderResizer, RESIZER_WIDTH } from "./header-resizer";
-import { TableCell } from "./table-cell";
+import { TableCell } from "../table-cell";
+import { Dimensions } from "../../../utils/dimensions";
 
 export class TableHeaderCell extends TableCell {
   private headerFilter: HeaderFilter;
@@ -53,16 +53,13 @@ export class TableHeaderCell extends TableCell {
     return isResizerHovered;
   }
 
-  private drawClippedContent(ctx: CanvasRenderingContext2D): void {
-    const {
-      left: leftPadding,
-      right: rightPadding,
-      top: topPadding,
-    } = getPadding(this.style?.padding);
-
-    const innerWidth = this.dimensions.w - leftPadding - rightPadding;
-    const innerHeight =
-      this.dimensions.h - topPadding - (this.style?.padding?.bottom ?? 0);
+  public drawClipped(
+    ctx: CanvasRenderingContext2D,
+    clippedDimensions: Dimensions,
+    padding: Required<Padding>,
+  ): void {
+    const innerWidth = clippedDimensions.w;
+    const innerHeight = clippedDimensions.h;
 
     ctx.save();
 
@@ -72,8 +69,8 @@ export class TableHeaderCell extends TableCell {
 
     ctx.beginPath();
     ctx.rect(
-      this.point.x + leftPadding,
-      this.point.y + topPadding,
+      this.point.x + padding.left,
+      this.point.y + padding.top,
       innerWidth,
       innerHeight,
     );
@@ -82,12 +79,12 @@ export class TableHeaderCell extends TableCell {
     const { x, textAlign } = this.getAlignment(innerWidth);
     ctx.textAlign = textAlign;
 
-    const y = this.point.y + topPadding + innerHeight / 2;
+    const y = this.point.y + padding.top + innerHeight / 2;
 
     ctx.fillText(this.data?.getDisplayableContent() ?? "NA", x, y);
 
-    const filterX = this.point.x + this.dimensions.w - rightPadding - 6;
-    const filterY = this.point.y + topPadding + innerHeight / 2;
+    const filterX = this.point.x + this.dimensions.w - padding.right - 6;
+    const filterY = this.point.y + padding.top + innerHeight / 2;
 
     ctx.save();
     ctx.translate(filterX, filterY);
@@ -97,21 +94,12 @@ export class TableHeaderCell extends TableCell {
     ctx.restore();
   }
 
-  private drawOverlay(ctx: CanvasRenderingContext2D): void {
+  public drawGlobal(ctx: CanvasRenderingContext2D): void {
     const resizerX = this.point.x + this.dimensions.w - RESIZER_WIDTH;
 
     ctx.save();
     ctx.translate(resizerX, this.point.y);
     this.headerResizer.draw(ctx);
-    ctx.restore();
-  }
-
-  public draw(ctx: CanvasRenderingContext2D): void {
-    ctx.save();
-
-    this.drawClippedContent(ctx);
-    this.drawOverlay(ctx);
-
     ctx.restore();
   }
 }

--- a/src/table/components/header/table-header.ts
+++ b/src/table/components/header/table-header.ts
@@ -1,16 +1,16 @@
-import { TableConfig, TableRow } from "../../types/table-config";
-import { Camera } from "../../utils/camera";
-import { Dimensions } from "../../utils/dimensions";
-import { DrawCanvas } from "../../utils/draw-canvas";
-import { StringTableData } from "../../utils/string-table-data";
-import { ColumnSizeMap } from "../../utils/column-size-map";
-import { CellPool } from "../../utils/cell-pool";
-import { SortedRowModel } from "../../utils/sorted-row-model";
-import { TableWorker } from "../table-worker";
-import { Mouse } from "../../utils/mouse";
-import { Point } from "../../utils/point";
+import { TableConfig, TableRow } from "../../../types/table-config";
+import { Camera } from "../../../utils/camera";
+import { Dimensions } from "../../../utils/dimensions";
+import { DrawCanvas } from "../../../utils/draw-canvas";
+import { StringTableData } from "../../../utils/string-table-data";
+import { ColumnSizeMap } from "../../../utils/column-size-map";
+import { CellPool } from "../../../utils/cell-pool";
+import { SortedRowModel } from "../../../utils/sorted-row-model";
+import { TableWorker } from "../../table-worker";
+import { Mouse } from "../../../utils/mouse";
+import { Point } from "../../../utils/point";
 import { TableHeaderCell } from "./table-header-cell";
-import { BufferedStream } from "../../utils/buffered-stream";
+import { BufferedStream } from "../../../utils/buffered-stream";
 
 export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
   private cellPool: CellPool<TableHeaderCell>;

--- a/src/table/components/table-cell.ts
+++ b/src/table/components/table-cell.ts
@@ -1,4 +1,4 @@
-import { TableCellStyles } from "../../types/table-cell-types";
+import { Padding, TableCellStyles } from "../../types/table-cell-types";
 import { Dimensions } from "../../utils/dimensions";
 import { WorldObject } from "../../utils/world-object";
 import { TableData } from "../../utils/table-data";
@@ -10,7 +10,7 @@ import {
 } from "../../utils/cell-style-defaults";
 import { getPadding } from "../../utils/padding-utils";
 
-export class TableCell extends WorldObject {
+export abstract class TableCell extends WorldObject {
   protected data: TableData<unknown> | null = null;
   protected dimensions: Dimensions = new Dimensions();
   protected _tempBoundingBox: BoundingBox | undefined;
@@ -55,6 +55,14 @@ export class TableCell extends WorldObject {
     return this._tempBoundingBox;
   }
 
+  public abstract drawClipped(
+    ctx: CanvasRenderingContext2D,
+    clippedDimensions: Dimensions,
+    padding: Required<Padding>,
+  ): void;
+
+  public abstract drawGlobal(ctx: CanvasRenderingContext2D): void;
+
   public draw(ctx: CanvasRenderingContext2D): void {
     ctx.save();
 
@@ -62,12 +70,15 @@ export class TableCell extends WorldObject {
     ctx.fillStyle = this.style?.text?.color ?? DEFAULT_TEXT_COLOR;
     ctx.textBaseline = "middle";
 
+    this.drawGlobal(ctx);
+
+    const padding = getPadding(this.style?.padding);
     const {
       left: leftPadding,
       right: rightPadding,
       top: topPadding,
       bottom: bottomPadding,
-    } = getPadding(this.style?.padding);
+    } = padding;
 
     ctx.beginPath();
     const innerWidth = this.dimensions.w - leftPadding - rightPadding;
@@ -80,13 +91,7 @@ export class TableCell extends WorldObject {
     );
     ctx.clip();
 
-    const { x, textAlign } = this.getAlignment(innerWidth);
-
-    ctx.textAlign = textAlign;
-
-    const y = this.point.y + topPadding + innerHeight / 2;
-
-    ctx.fillText(this.data?.getDisplayableContent() ?? "NA", x, y);
+    this.drawClipped(ctx, new Dimensions(innerWidth, innerHeight), padding);
 
     ctx.restore();
   }

--- a/src/table/table-body-overlay.ts
+++ b/src/table/table-body-overlay.ts
@@ -6,7 +6,7 @@ export class TableBodyOverlay {
     this.rowActionContainer.style.position = "absolute";
     this.rowActionContainer.style.width = "100%";
     this.rowActionContainer.style.height = `${rowHeight}px`;
-    this.rowActionContainer.style.background = "red";
+    this.rowActionContainer.style.background = "transparent";
     this.rowActionContainer.style.opacity = "0";
     this.rowActionContainer.style.top = "0";
     parent.appendChild(this.rowActionContainer);

--- a/src/table/table.ts
+++ b/src/table/table.ts
@@ -18,8 +18,8 @@ import {
   HORIZONTAL_SCROLLBAR_HEIGHT,
   HorizontalScrollbar,
 } from "./components/horizontal-scrollbar";
-import { TableBody } from "./components/table-body";
-import { TableHeader } from "./components/table-header";
+import { TableBody } from "./components/body/table-body";
+import { TableHeader } from "./components/header/table-header";
 import {
   VERTICAL_SCROLLBAR_WIDTH,
   VerticalScrollbar,
@@ -155,7 +155,6 @@ export class Table<TDataRow extends TableRow> implements Closeable {
       this.mouse,
       this.sortedRowModel,
       this.cellDataStore,
-      this.columnLookup,
       new Dimensions(
         this.rootDimensions.w - VERTICAL_SCROLLBAR_WIDTH,
         this.rootDimensions.h -

--- a/src/utils/column-size-map.ts
+++ b/src/utils/column-size-map.ts
@@ -13,7 +13,7 @@ import { Point } from "./point";
 import { TableColumnDef, TableRow } from "../types/table-config";
 import { ColumnConstraints } from "../types/column-constraints";
 import { clamp } from "./clamp";
-import { RESIZER_EFFECTIVE_WIDTH } from "../table/components/header-resizer";
+import { RESIZER_EFFECTIVE_WIDTH } from "../table/components/header/header-resizer";
 import { Closeable } from "./closeable";
 
 type BoundingBoxMetadata = { columnId: string; columnIndex: number };

--- a/src/worker/column-size-manager.ts
+++ b/src/worker/column-size-manager.ts
@@ -1,4 +1,4 @@
-import { HEADER_FILTER_BUFFER } from "../table/components/header-filter";
+import { HEADER_FILTER_BUFFER } from "../table/components/header/header-filter";
 import { ColumnConstraints } from "../types/column-constraints";
 import { TableCellStyles } from "../types/table-cell-types";
 import { DEFAULT_FONT_STRING } from "../utils/cell-style-defaults";


### PR DESCRIPTION
This PR updates the table cell to an abstract class with methods to implement rendering for cell content. This is in preparation to allow consumers to provide their own draw implementations on table cells.

Hover state has been updated - at the canvas cell level there is now a hover state that allows highlighting/drawing custom behavior when the mouse hovers a row. The overlay system remains intact allowing consumers to inject html elements such as action buttons to the row.



Folder structure is organized by header and body components under new respective directories.