### PR TITLE
round cell widths to whole numbers and fix gap between hovered cell styles

### DIFF
--- a/src/table/components/body/table-body-cell.ts
+++ b/src/table/components/body/table-body-cell.ts
@@ -49,12 +49,12 @@ export class TableBodyCell extends TableCell {
     ctx.save();
 
     if (this.isHovered) {
-      ctx.fillStyle = "red";
+      ctx.fillStyle = "black";
 
       ctx.fillRect(
         this.point.x,
         this.point.y,
-        this.dimensions.w,
+        this.dimensions.w + 1, // todo - figure out why a sometimes a 1px gap appears between cells without this
         this.dimensions.h,
       );
     }

--- a/src/worker/column-size-manager.ts
+++ b/src/worker/column-size-manager.ts
@@ -44,8 +44,9 @@ export class ColumnSizeManager {
     const { left: leftPadding, right: rightPadding } = getPadding(
       this.cellStyling?.padding,
     );
-    const computedWidth =
-      computedMetrics.width + leftPadding + rightPadding + HEADER_FILTER_BUFFER;
+    const computedWidth = Math.ceil(
+      computedMetrics.width + leftPadding + rightPadding + HEADER_FILTER_BUFFER,
+    );
     const newCellWidth = Math.min(
       this.columnConstraints[columnId].maxWidth,
       Math.max(


### PR DESCRIPTION
This PR updates the column sizing worker to use whole numbers by rounding up to the nearest whole. It also adds a patch to a visual bug where hovered cells sometimes show a 1px gap between each other. 