### PR TITLE
reinitialize cell pool on table resize

### DIFF
--- a/src/table/components/body/table-body.ts
+++ b/src/table/components/body/table-body.ts
@@ -37,7 +37,7 @@ export class TableBody<TDataRow extends TableRow>
   implements Closeable
 {
   private canvasWrapperDiv: HTMLDivElement;
-  private cellPool: CellPool<TableBodyCell>;
+  private cellPool!: CellPool<TableBodyCell>;
   private sourceSubscription: Subscription;
   private columnResizeSubscription: Subscription;
   private hoveredRowIndex: number | undefined;
@@ -67,18 +67,7 @@ export class TableBody<TDataRow extends TableRow>
       this.config.style.body.row.height,
     );
 
-    this.cellPool = new CellPool();
-    this.cellPool.initFromViewport({
-      viewportHeight: this.camera.viewportHeight,
-      viewportWidth: this.camera.viewportWidth,
-      bufferX: 4,
-      bufferY: 4,
-      rowHeight: this.config.style.body.row.height,
-      minColumnWidth: this.columnSizes.getMinColumnWidth(),
-      cellFactory: () => {
-        return new TableBodyCell(this.config.style.body.cell);
-      },
-    });
+    this.initializeCellPool();
 
     this.sourceSubscription = this.source.subscribe(this.handleRecvSourceData);
     this.columnResizeSubscription = this.getColumnResizeObservables(
@@ -112,6 +101,21 @@ export class TableBody<TDataRow extends TableRow>
     this.mouse.onMouseLost(this.mouseLost);
 
     this.requestRedraw();
+  }
+
+  public initializeCellPool(): void {
+    this.cellPool = new CellPool();
+    this.cellPool.initFromViewport({
+      viewportHeight: this.camera.viewportHeight,
+      viewportWidth: this.camera.viewportWidth,
+      bufferX: 4,
+      bufferY: 4,
+      rowHeight: this.config.style.body.row.height,
+      minColumnWidth: this.columnSizes.getMinColumnWidth(),
+      cellFactory: () => {
+        return new TableBodyCell(this.config.style.body.cell);
+      },
+    });
   }
 
   public getElement(): HTMLElement {

--- a/src/table/components/header/table-header.ts
+++ b/src/table/components/header/table-header.ts
@@ -13,7 +13,7 @@ import { TableHeaderCell } from "./table-header-cell";
 import { BufferedStream } from "../../../utils/buffered-stream";
 
 export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
-  private cellPool: CellPool<TableHeaderCell>;
+  private cellPool!: CellPool<TableHeaderCell>;
   private headerNameMap: Map<string, string>;
   private clickStartPosition: Point = new Point();
   private hoveredViewportPosition: Point | undefined = new Point();
@@ -44,13 +44,7 @@ export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
       }),
     );
 
-    this.cellPool = new CellPool();
-    this.cellPool.initFromCount({
-      count: this.config.columns.length,
-      cellFactory: () => {
-        return new TableHeaderCell(this.config.style.header.cell);
-      },
-    });
+    this.initializeCellPool();
 
     this.config.columns.forEach(({ columnId, name }) => {
       this.tableWorker.send({
@@ -82,6 +76,16 @@ export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
     this.mouse.onMouseMove(this.handleMouseMove);
     this.mouse.onMouseUp(this.handleMouseUp);
     this.requestRedraw();
+  }
+
+  public initializeCellPool(): void {
+    this.cellPool = new CellPool();
+    this.cellPool.initFromCount({
+      count: this.config.columns.length,
+      cellFactory: () => {
+        return new TableHeaderCell(this.config.style.header.cell);
+      },
+    });
   }
 
   handleMouseMove = (p: Point) => {

--- a/src/table/table.ts
+++ b/src/table/table.ts
@@ -220,6 +220,9 @@ export class Table<TDataRow extends TableRow> implements Closeable {
         w: width,
         h: height,
       });
+
+      this.body.initializeCellPool();
+      this.header.initializeCellPool();
     });
 
     this.resizeObserver.observe(this.root);


### PR DESCRIPTION
This PR reinitializes the cell pool for the table body and header when the table is resized to ensure there are enough cells in the pool to cover the upper bound of all content being rendered on the viewport.



fixes #49