### PR TITLE
clean up cell pool reinitialization

### DIFF
--- a/src/table/components/body/table-body.ts
+++ b/src/table/components/body/table-body.ts
@@ -37,7 +37,7 @@ export class TableBody<TDataRow extends TableRow>
   implements Closeable
 {
   private canvasWrapperDiv: HTMLDivElement;
-  private cellPool!: CellPool<TableBodyCell>;
+  private cellPool: CellPool<TableBodyCell>;
   private sourceSubscription: Subscription;
   private columnResizeSubscription: Subscription;
   private hoveredRowIndex: number | undefined;
@@ -67,7 +67,7 @@ export class TableBody<TDataRow extends TableRow>
       this.config.style.body.row.height,
     );
 
-    this.initializeCellPool();
+    this.cellPool = this.createCellPool();
 
     this.sourceSubscription = this.source.subscribe(this.handleRecvSourceData);
     this.columnResizeSubscription = this.getColumnResizeObservables(
@@ -103,9 +103,12 @@ export class TableBody<TDataRow extends TableRow>
     this.requestRedraw();
   }
 
-  public initializeCellPool(): void {
-    this.cellPool = new CellPool();
-    this.cellPool.initFromViewport({
+  public reinitializeCellPool(): void {
+    this.cellPool = this.createCellPool();
+  }
+
+  private createCellPool(): CellPool<TableBodyCell> {
+    return CellPool.initFromViewport({
       viewportHeight: this.camera.viewportHeight,
       viewportWidth: this.camera.viewportWidth,
       bufferX: 4,

--- a/src/table/components/header/table-header.ts
+++ b/src/table/components/header/table-header.ts
@@ -13,7 +13,7 @@ import { TableHeaderCell } from "./table-header-cell";
 import { BufferedStream } from "../../../utils/buffered-stream";
 
 export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
-  private cellPool!: CellPool<TableHeaderCell>;
+  private cellPool: CellPool<TableHeaderCell>;
   private headerNameMap: Map<string, string>;
   private clickStartPosition: Point = new Point();
   private hoveredViewportPosition: Point | undefined = new Point();
@@ -44,7 +44,12 @@ export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
       }),
     );
 
-    this.initializeCellPool();
+    this.cellPool = CellPool.initFromCount({
+      count: this.config.columns.length,
+      cellFactory: () => {
+        return new TableHeaderCell(this.config.style.header.cell);
+      },
+    });
 
     this.config.columns.forEach(({ columnId, name }) => {
       this.tableWorker.send({
@@ -76,16 +81,6 @@ export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
     this.mouse.onMouseMove(this.handleMouseMove);
     this.mouse.onMouseUp(this.handleMouseUp);
     this.requestRedraw();
-  }
-
-  public initializeCellPool(): void {
-    this.cellPool = new CellPool();
-    this.cellPool.initFromCount({
-      count: this.config.columns.length,
-      cellFactory: () => {
-        return new TableHeaderCell(this.config.style.header.cell);
-      },
-    });
   }
 
   handleMouseMove = (p: Point) => {

--- a/src/table/table.ts
+++ b/src/table/table.ts
@@ -220,9 +220,7 @@ export class Table<TDataRow extends TableRow> implements Closeable {
         w: width,
         h: height,
       });
-
-      this.body.initializeCellPool();
-      this.header.initializeCellPool();
+      this.body.reinitializeCellPool();
     });
 
     this.resizeObserver.observe(this.root);

--- a/src/utils/cell-pool.ts
+++ b/src/utils/cell-pool.ts
@@ -19,19 +19,21 @@ export class CellPool<TCell extends TableCell> {
     return this.cells[this.index++];
   }
 
-  public initFromCount({
+  public static initFromCount<TCell extends TableCell>({
     count,
     cellFactory,
   }: {
     count: number;
     cellFactory: () => TCell;
-  }): void {
+  }): CellPool<TCell> {
+    const cellPool = new CellPool<TCell>();
     for (let i = 0; i < count; i++) {
-      this.addCell(cellFactory());
+      cellPool.addCell(cellFactory());
     }
+    return cellPool;
   }
 
-  public initFromViewport({
+  public static initFromViewport<TCell extends TableCell>({
     viewportWidth,
     viewportHeight,
     rowHeight,
@@ -47,16 +49,17 @@ export class CellPool<TCell extends TableCell> {
     rowHeight: number;
     minColumnWidth: number;
     cellFactory: () => TCell;
-  }): void {
+  }): CellPool<TCell> {
+    const cellPool = new CellPool<TCell>();
+
     const maxVisibleRows = Math.ceil(viewportHeight / rowHeight) + bufferX;
-
     const maxVisibleCols = Math.ceil(viewportWidth / minColumnWidth) + bufferY;
-
     const poolSize = maxVisibleRows * maxVisibleCols;
 
     for (let i = 0; i < poolSize; i++) {
-      this.addCell(cellFactory());
+      cellPool.addCell(cellFactory());
     }
+    return cellPool;
   }
 
   public *allCells(): IterableIterator<TableCell> {


### PR DESCRIPTION
This PR cleans up repeated code in the cell pool initialization path and removes the reinitialization for the table header because the cell pool is always initialized to its full size in the header's constructor.