### PR TITLE
initialize non uniform cell pool

### DIFF
--- a/sample/vite/src/pages/L2/utils/p50RenderCell.ts
+++ b/sample/vite/src/pages/L2/utils/p50RenderCell.ts
@@ -1,0 +1,26 @@
+import { Dimensions, TableCell } from "../../../../../../dist";
+
+export class P50RenderCell extends TableCell {
+  drawClipped(
+    ctx: CanvasRenderingContext2D,
+    clippedDimensions: Dimensions,
+    padding: Required<{
+      top?: number;
+      bottom?: number;
+      left?: number;
+      right?: number;
+    }>,
+  ): void {
+    // ctx.fillStyle = "green";
+    // ctx.fillRect(
+    //   this.point.x + padding.left,
+    //   this.point.y - padding.top,
+    //   clippedDimensions.w,
+    //   clippedDimensions.h,
+    // );
+  }
+  drawGlobal(ctx: CanvasRenderingContext2D): void {
+    ctx.fillStyle = "purple";
+    ctx.fillRect(this.point.x, this.point.y, this.w, this.h);
+  }
+}

--- a/sample/vite/src/pages/L2/utils/tableConfig.ts
+++ b/sample/vite/src/pages/L2/utils/tableConfig.ts
@@ -4,6 +4,7 @@ import type {
   TableConfig,
 } from "../../../../../../dist";
 import { NumberTableData } from "./numberTableData";
+import { P50RenderCell } from "./p50RenderCell";
 
 export type StatsRow = TableRow & {
   placeholders: {
@@ -71,6 +72,7 @@ const columns: Array<TableColumnDef<StatsRow, number>> = [
     autoResize: false,
     placeholderAccessorFn: (row) => row.placeholders.p50,
     cellData: () => new NumberTableData(),
+    renderCell: () => new P50RenderCell(),
   },
   {
     columnId: "p75",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,5 @@ export type {
 } from "./types/table-config";
 export { StringTableData } from "./utils/string-table-data";
 export { TableData } from "./utils/table-data";
+export { TableCell } from "./table/components/table-cell";
+export { Dimensions } from "./utils/dimensions";

--- a/src/table/components/body/table-body-cell.ts
+++ b/src/table/components/body/table-body-cell.ts
@@ -1,36 +1,8 @@
 import { Padding } from "../../../types/table-cell-types";
 import { Dimensions } from "../../../utils/dimensions";
-import { TableData } from "../../../utils/table-data";
 import { TableCell } from "../table-cell";
 
 export class TableBodyCell extends TableCell {
-  private isHovered: boolean = false;
-
-  public bind({
-    x,
-    y,
-    data,
-    width,
-    height,
-    isHovered,
-  }: {
-    x: number;
-    y: number;
-    data: TableData<unknown>;
-    width: number;
-    height: number;
-    isHovered: boolean;
-  }): void {
-    super.bind({
-      x,
-      y,
-      data,
-      width,
-      height,
-    });
-    this.isHovered = isHovered;
-  }
-
   public drawClipped(
     ctx: CanvasRenderingContext2D,
     clippedDimensions: Dimensions,

--- a/src/table/components/body/table-body.ts
+++ b/src/table/components/body/table-body.ts
@@ -15,7 +15,6 @@ import {
   calculateTopAndBottomRowBounds,
 } from "../../../utils/boundary-search";
 import { Axis } from "../../../utils/axis";
-import { CellPool } from "../../../utils/cell-pool";
 import { Closeable } from "../../../utils/closeable";
 import { CellDataStore } from "../../../utils/cell-data-store";
 import { TableData } from "../../../utils/table-data";
@@ -25,6 +24,9 @@ import { Mouse } from "../../../utils/mouse";
 import { TableBodyOverlay } from "../../table-body-overlay";
 import { SortedRowModel } from "../../../utils/sorted-row-model";
 import { TableBodyCell } from "./table-body-cell";
+import { NonUniformCellPool } from "../../../utils/nonuniform-cell-pool";
+import { TableCell } from "../table-cell";
+import { TableCellStyles } from "../../../types/table-cell-types";
 
 type VirtualBounds = {
   leftColumnIndex: number;
@@ -37,7 +39,7 @@ export class TableBody<TDataRow extends TableRow>
   implements Closeable
 {
   private canvasWrapperDiv: HTMLDivElement;
-  private cellPool: CellPool<TableBodyCell>;
+  private cellPool: NonUniformCellPool;
   private sourceSubscription: Subscription;
   private columnResizeSubscription: Subscription;
   private hoveredRowIndex: number | undefined;
@@ -107,17 +109,16 @@ export class TableBody<TDataRow extends TableRow>
     this.cellPool = this.createCellPool();
   }
 
-  private createCellPool(): CellPool<TableBodyCell> {
-    return CellPool.fromViewport({
+  private createCellPool(): NonUniformCellPool {
+    return NonUniformCellPool.fromViewport({
       viewportHeight: this.camera.viewportHeight,
-      viewportWidth: this.camera.viewportWidth,
-      bufferX: 4,
       bufferY: 4,
       rowHeight: this.config.style.body.row.height,
       minColumnWidth: this.columnSizes.getMinColumnWidth(),
-      cellFactory: () => {
-        return new TableBodyCell(this.config.style.body.cell);
-      },
+      cellFactories: extractRenderCellFactories(
+        this.config.columns,
+        this.config.style.body.cell,
+      ),
     });
   }
 
@@ -278,8 +279,8 @@ export class TableBody<TDataRow extends TableRow>
     for (let r = topRowIndex; r <= bottomRowIndex; r++) {
       const row = this.sortedRowModel.getRow(r);
       for (let c = leftColumnIndex; c <= rightColumnIndex; c++) {
-        const cell = this.cellPool.next();
         const column = this.config.columns[c];
+        const cell = this.cellPool.next(column.columnId);
         cell.bind({
           x: this.columnSizes.getColumnXPos(column.columnId) ?? 0,
           y: r * this.config.style.body.row.height,
@@ -298,7 +299,10 @@ export class TableBody<TDataRow extends TableRow>
   }
 
   public draw(ctx: CanvasRenderingContext2D): void {
-    ctx.translate(-this.camera.x, -this.camera.y);
+    ctx.translate(
+      -this.snapToDevicePixel(this.camera.x),
+      -this.snapToDevicePixel(this.camera.y),
+    );
 
     this.drawCells(ctx);
   }
@@ -314,4 +318,17 @@ function tableDataFactoryWithPlaceholder<TDataRow extends TableRow>(
     cellData.setValue(initialValue);
     return cellData;
   };
+}
+
+function extractRenderCellFactories<TDataRow extends TableRow>(
+  columnDefs: Array<TableColumnDef<TDataRow>>,
+  tableCellStyles: TableCellStyles | undefined,
+): Record<string, () => TableCell> {
+  const defaultTableBodyCellFactory = () => new TableBodyCell(tableCellStyles);
+  const accumulator: Record<string, () => TableCell> = {};
+  const res = columnDefs.reduce((acc, curr) => {
+    acc[curr.columnId] = curr.renderCell ?? defaultTableBodyCellFactory;
+    return acc;
+  }, accumulator);
+  return res;
 }

--- a/src/table/components/header/table-header.ts
+++ b/src/table/components/header/table-header.ts
@@ -214,7 +214,7 @@ export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
   }
 
   public draw(ctx: CanvasRenderingContext2D): void {
-    ctx.translate(-this.camera.x, 0);
+    ctx.translate(-this.snapToDevicePixel(this.camera.x), 0);
 
     this.drawCells(ctx);
   }

--- a/src/table/components/table-cell.ts
+++ b/src/table/components/table-cell.ts
@@ -15,7 +15,9 @@ export abstract class TableCell extends WorldObject {
   protected dimensions: Dimensions = new Dimensions();
   protected _tempBoundingBox: BoundingBox | undefined;
 
-  constructor(protected readonly style: TableCellStyles | undefined) {
+  protected isHovered: boolean = false;
+
+  constructor(protected readonly style?: TableCellStyles) {
     super();
   }
 
@@ -25,18 +27,21 @@ export abstract class TableCell extends WorldObject {
     data,
     width,
     height,
+    isHovered = false,
   }: {
     x: number;
     y: number;
     data: TableData<unknown>;
     width: number;
     height: number;
+    isHovered?: boolean;
   }): void {
     this.point.x = x;
     this.point.y = y;
     this.dimensions.w = width;
     this.dimensions.h = height;
     this.data = data;
+    this.isHovered = isHovered;
   }
 
   public get w(): number {

--- a/src/types/table-config.ts
+++ b/src/types/table-config.ts
@@ -1,6 +1,7 @@
 import { Observable } from "rxjs";
 import { TableData } from "../utils/table-data";
 import { TableCellStyles } from "./table-cell-types";
+import { TableCell } from "../table/components/table-cell";
 
 export type TableOptions<TDataRow extends TableRow> = {
   config: TableConfig<TDataRow>;
@@ -37,6 +38,7 @@ export type TableColumnDef<TDataRow extends TableRow, TValue = unknown> = {
   autoResize: boolean;
   placeholderAccessorFn: (row: TDataRow) => TValue;
   cellData: () => TableData<TValue>;
+  renderCell?: () => TableCell;
 };
 
 export type TableRow = {

--- a/src/utils/cell-pool.ts
+++ b/src/utils/cell-pool.ts
@@ -52,8 +52,8 @@ export class CellPool<TCell extends TableCell> {
   }): CellPool<TCell> {
     const cellPool = new CellPool<TCell>();
 
-    const maxVisibleRows = Math.ceil(viewportHeight / rowHeight) + bufferX;
-    const maxVisibleCols = Math.ceil(viewportWidth / minColumnWidth) + bufferY;
+    const maxVisibleRows = Math.ceil(viewportHeight / rowHeight) + bufferY;
+    const maxVisibleCols = Math.ceil(viewportWidth / minColumnWidth) + bufferX;
     const poolSize = maxVisibleRows * maxVisibleCols;
 
     for (let i = 0; i < poolSize; i++) {

--- a/src/utils/draw-canvas.ts
+++ b/src/utils/draw-canvas.ts
@@ -7,6 +7,7 @@ import { Dimensions } from "./dimensions";
 export abstract class DrawCanvas extends Canvas implements Closeable, Drawable {
   private ctx: CanvasRenderingContext2D;
   private drawQueue$: ReplaySubject<void>;
+  protected dpr: number = 1;
 
   constructor(dimensions: Dimensions) {
     super(dimensions);
@@ -16,6 +17,7 @@ export abstract class DrawCanvas extends Canvas implements Closeable, Drawable {
   }
 
   public resize(w: number, h: number, dpr: number = 1): void {
+    this.dpr = dpr;
     this.canvas.width = Math.round(w * dpr);
     this.canvas.height = Math.round(h * dpr);
     this.resizeCanvas(w, h);
@@ -44,5 +46,9 @@ export abstract class DrawCanvas extends Canvas implements Closeable, Drawable {
 
   public close(): void {
     this.drawQueue$.complete();
+  }
+
+  protected snapToDevicePixel(value: number): number {
+    return Math.round(value * this.dpr) / this.dpr;
   }
 }

--- a/src/utils/nonuniform-cell-pool.ts
+++ b/src/utils/nonuniform-cell-pool.ts
@@ -1,0 +1,57 @@
+import { TableCell } from "../table/components/table-cell";
+import { CellPool } from "./cell-pool";
+
+export class NonUniformCellPool {
+  private cellPools: Map<string, CellPool<TableCell>> = new Map();
+
+  public beginFrame(): void {
+    this.cellPools.forEach((cellPool) => cellPool.beginFrame());
+  }
+
+  public next(columnId: string): TableCell {
+    const cellPool = this.cellPools.get(columnId);
+    if (!cellPool) {
+      throw new Error(`Cell pool for column ${columnId} not initialized`);
+    }
+    return cellPool.next();
+  }
+
+  public addColumnCells(
+    columnId: string,
+    cellCount: number,
+    cellFactory: () => TableCell,
+  ): void {
+    let cellPool = this.cellPools.get(columnId);
+    if (!cellPool) {
+      cellPool = new CellPool();
+      this.cellPools.set(columnId, cellPool);
+    }
+
+    for (let i = 0; i < cellCount; i++) {
+      cellPool.addCell(cellFactory());
+    }
+  }
+
+  public static fromViewport({
+    viewportHeight,
+    rowHeight,
+    bufferY,
+    cellFactories,
+  }: {
+    viewportHeight: number;
+    bufferY: number;
+    rowHeight: number;
+    minColumnWidth: number;
+    cellFactories: Record<string, () => TableCell>;
+  }): NonUniformCellPool {
+    const nonuniformCellPool = new NonUniformCellPool();
+
+    const maxVisibleRows = Math.ceil(viewportHeight / rowHeight) + bufferY;
+
+    for (const [columnId, cellFactory] of Object.entries(cellFactories)) {
+      nonuniformCellPool.addColumnCells(columnId, maxVisibleRows, cellFactory);
+    }
+
+    return nonuniformCellPool;
+  }
+}


### PR DESCRIPTION
This PR moves hover state for the table cells from the body specific cell implementation into the root table cell. Also adds a `NonuniformCellPool`which allows for different columns to provide their own cell implementations that extends `TableCell`. The config is updated to allow this on the consumer.

Also added a fix for some subpixel render artifacts that were showing up because the camera's X,Y positions could be fractional.

fixes #52