### PR TITLE
delegate context mutation to new painter class

### DIFF
--- a/sample/vite/src/pages/L2/utils/p50RenderCell.ts
+++ b/sample/vite/src/pages/L2/utils/p50RenderCell.ts
@@ -1,8 +1,8 @@
-import { Dimensions, TableCell } from "../../../../../../dist";
+import { Dimensions, Painter, TableCell } from "../../../../../../dist";
 
 export class P50RenderCell extends TableCell {
   drawClipped(
-    ctx: CanvasRenderingContext2D,
+    painter: Painter,
     clippedDimensions: Dimensions,
     padding: Required<{
       top?: number;
@@ -11,16 +11,10 @@ export class P50RenderCell extends TableCell {
       right?: number;
     }>,
   ): void {
-    // ctx.fillStyle = "green";
-    // ctx.fillRect(
-    //   this.point.x + padding.left,
-    //   this.point.y - padding.top,
-    //   clippedDimensions.w,
-    //   clippedDimensions.h,
-    // );
+    void this.drawClipped;
   }
-  drawGlobal(ctx: CanvasRenderingContext2D): void {
-    ctx.fillStyle = "purple";
-    ctx.fillRect(this.point.x, this.point.y, this.w, this.h);
+
+  drawGlobal(painter: Painter): void {
+    painter.drawRect(this.point, this.dimensions, "purple");
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export { StringTableData } from "./utils/string-table-data";
 export { TableData } from "./utils/table-data";
 export { TableCell } from "./table/components/table-cell";
 export { Dimensions } from "./utils/dimensions";
+export { Painter } from "./utils/painter";

--- a/src/table/components/body/table-body-cell.ts
+++ b/src/table/components/body/table-body-cell.ts
@@ -1,36 +1,35 @@
 import { Padding } from "../../../types/table-cell-types";
 import { Dimensions } from "../../../utils/dimensions";
+import { Painter } from "../../../utils/painter";
+import { Point } from "../../../utils/point";
 import { TableCell } from "../table-cell";
 
 export class TableBodyCell extends TableCell {
   public drawClipped(
-    ctx: CanvasRenderingContext2D,
+    painter: Painter,
     clippedDimensions: Dimensions,
     padding: Required<Padding>,
   ): void {
     const { x, textAlign } = this.getAlignment(clippedDimensions.w);
 
-    ctx.textAlign = textAlign;
-
     const y = this.point.y + padding.top + clippedDimensions.h / 2;
 
-    ctx.fillText(this.data?.getDisplayableContent() ?? "NA", x, y);
+    const textContent = this.data?.getDisplayableContent() ?? "NA";
+    painter.writeText(textContent, Point.at(x, y), {
+      font: this.style?.text?.font,
+      color: this.style?.text?.color,
+      baseline: "middle",
+      alignment: textAlign,
+    });
   }
 
-  public drawGlobal(ctx: CanvasRenderingContext2D): void {
-    ctx.save();
-
+  public drawGlobal(painter: Painter): void {
     if (this.isHovered && this.style?.hovered?.backgroundColor) {
-      ctx.fillStyle = this.style?.hovered?.backgroundColor;
-
-      ctx.fillRect(
-        this.point.x,
-        this.point.y,
-        this.dimensions.w + 1,
-        this.dimensions.h,
+      painter.drawRect(
+        this.point,
+        this.dimensions,
+        this.style.hovered.backgroundColor,
       );
     }
-
-    ctx.restore();
   }
 }

--- a/src/table/components/body/table-body.ts
+++ b/src/table/components/body/table-body.ts
@@ -27,6 +27,7 @@ import { TableBodyCell } from "./table-body-cell";
 import { NonUniformCellPool } from "../../../utils/nonuniform-cell-pool";
 import { TableCell } from "../table-cell";
 import { TableCellStyles } from "../../../types/table-cell-types";
+import { Painter } from "../../../utils/painter";
 
 type VirtualBounds = {
   leftColumnIndex: number;
@@ -270,7 +271,7 @@ export class TableBody<TDataRow extends TableRow>
     };
   }
 
-  private drawCells(ctx: CanvasRenderingContext2D): void {
+  private drawCells(painter: Painter): void {
     this.cellPool.beginFrame();
 
     this._cachedVirtualBounds = this.getVirtualBounds();
@@ -293,18 +294,15 @@ export class TableBody<TDataRow extends TableRow>
           ),
           isHovered: this.hoveredRowIndex === r,
         });
-        cell.draw(ctx);
+        cell.draw(painter);
       }
     }
   }
 
-  public draw(ctx: CanvasRenderingContext2D): void {
-    ctx.translate(
-      -this.snapToDevicePixel(this.camera.x),
-      -this.snapToDevicePixel(this.camera.y),
-    );
+  public draw(painter: Painter): void {
+    painter.translateFromViewport(this.camera.x, this.camera.y);
 
-    this.drawCells(ctx);
+    this.drawCells(painter);
   }
 }
 

--- a/src/table/components/header/header-filter.ts
+++ b/src/table/components/header/header-filter.ts
@@ -1,4 +1,5 @@
 import { Drawable } from "../../../utils/drawable";
+import { Painter } from "../../../utils/painter";
 
 const HEADER_FILTER_WIDTH = 6;
 const HEADER_FILTER_SPACING = 2;
@@ -11,33 +12,43 @@ export class HeaderFilter implements Drawable {
     this.direction = direction;
   }
 
-  public draw(ctx: CanvasRenderingContext2D): void {
+  public draw(painter: Painter): void {
     const x = 0;
     const y = -HEADER_FILTER_WIDTH;
 
-    ctx.save();
+    painter.dangerouslyGetRenderingContext().save();
 
-    ctx.beginPath();
-    ctx.moveTo(x, y);
-    ctx.lineTo(x - HEADER_FILTER_WIDTH, y + HEADER_FILTER_WIDTH);
-    ctx.lineTo(x + HEADER_FILTER_WIDTH, y + HEADER_FILTER_WIDTH);
-    ctx.closePath();
-    ctx.fillStyle =
+    painter.dangerouslyGetRenderingContext().beginPath();
+    painter.dangerouslyGetRenderingContext().moveTo(x, y);
+    painter
+      .dangerouslyGetRenderingContext()
+      .lineTo(x - HEADER_FILTER_WIDTH, y + HEADER_FILTER_WIDTH);
+    painter
+      .dangerouslyGetRenderingContext()
+      .lineTo(x + HEADER_FILTER_WIDTH, y + HEADER_FILTER_WIDTH);
+    painter.dangerouslyGetRenderingContext().closePath();
+    painter.dangerouslyGetRenderingContext().fillStyle =
       this.direction === "ASC" ? "rgba(0,0,0,0.85)" : "rgba(0,0,0,0.3)";
-    ctx.fill();
+    painter.dangerouslyGetRenderingContext().fill();
 
     const downY = y + HEADER_FILTER_WIDTH + HEADER_FILTER_SPACING;
 
-    ctx.beginPath();
-    ctx.moveTo(x, downY + HEADER_FILTER_WIDTH);
-    ctx.lineTo(x - HEADER_FILTER_WIDTH, downY);
-    ctx.lineTo(x + HEADER_FILTER_WIDTH, downY);
-    ctx.closePath();
-    ctx.fillStyle =
+    painter.dangerouslyGetRenderingContext().beginPath();
+    painter
+      .dangerouslyGetRenderingContext()
+      .moveTo(x, downY + HEADER_FILTER_WIDTH);
+    painter
+      .dangerouslyGetRenderingContext()
+      .lineTo(x - HEADER_FILTER_WIDTH, downY);
+    painter
+      .dangerouslyGetRenderingContext()
+      .lineTo(x + HEADER_FILTER_WIDTH, downY);
+    painter.dangerouslyGetRenderingContext().closePath();
+    painter.dangerouslyGetRenderingContext().fillStyle =
       this.direction === "DESC" ? "rgba(0,0,0,0.85)" : "rgba(0,0,0,0.3)";
-    ctx.fill();
+    painter.dangerouslyGetRenderingContext().fill();
 
-    ctx.restore();
+    painter.dangerouslyGetRenderingContext().restore();
   }
 
   public setDirection(direction: "ASC" | "DESC" | undefined) {

--- a/src/table/components/header/header-resizer.ts
+++ b/src/table/components/header/header-resizer.ts
@@ -1,5 +1,6 @@
 import { BoundingBox } from "../../../utils/bounding-box";
 import { Dimensions } from "../../../utils/dimensions";
+import { Painter } from "../../../utils/painter";
 import { Point } from "../../../utils/point";
 import { WorldObject } from "../../../utils/world-object";
 
@@ -46,14 +47,13 @@ export class HeaderResizer extends WorldObject {
     return this.resizerBoundingBox;
   }
 
-  public draw(ctx: CanvasRenderingContext2D): void {
+  public draw(painter: Painter): void {
     if (!this.isShowResizer) return;
 
-    ctx.save();
-
-    ctx.fillStyle = "red";
-    ctx.fillRect(0, 0, RESIZER_WIDTH, this.resizerHeight);
-
-    ctx.restore();
+    painter.drawRect(
+      Point.at(0, 0),
+      Dimensions.of(RESIZER_WIDTH, this.resizerHeight),
+      "red",
+    );
   }
 }

--- a/src/table/components/header/table-header-cell.ts
+++ b/src/table/components/header/table-header-cell.ts
@@ -1,14 +1,11 @@
 import { Padding, TableCellStyles } from "../../../types/table-cell-types";
-import {
-  DEFAULT_FONT_STRING,
-  DEFAULT_TEXT_COLOR,
-} from "../../../utils/cell-style-defaults";
 import { Point } from "../../../utils/point";
 import { TableData } from "../../../utils/table-data";
 import { HeaderFilter } from "./header-filter";
 import { HeaderResizer, RESIZER_WIDTH } from "./header-resizer";
 import { TableCell } from "../table-cell";
 import { Dimensions } from "../../../utils/dimensions";
+import { Painter } from "../../../utils/painter";
 
 export class TableHeaderCell extends TableCell {
   private headerFilter: HeaderFilter;
@@ -54,52 +51,40 @@ export class TableHeaderCell extends TableCell {
   }
 
   public drawClipped(
-    ctx: CanvasRenderingContext2D,
+    painter: Painter,
     clippedDimensions: Dimensions,
     padding: Required<Padding>,
   ): void {
     const innerWidth = clippedDimensions.w;
     const innerHeight = clippedDimensions.h;
 
-    ctx.save();
-
-    ctx.font = this.style?.text?.font ?? DEFAULT_FONT_STRING;
-    ctx.fillStyle = this.style?.text?.color ?? DEFAULT_TEXT_COLOR;
-    ctx.textBaseline = "middle";
-
-    ctx.beginPath();
-    ctx.rect(
-      this.point.x + padding.left,
-      this.point.y + padding.top,
-      innerWidth,
-      innerHeight,
-    );
-    ctx.clip();
-
     const { x, textAlign } = this.getAlignment(innerWidth);
-    ctx.textAlign = textAlign;
 
     const y = this.point.y + padding.top + innerHeight / 2;
+    const textContent = this.data?.getDisplayableContent() ?? "NA";
 
-    ctx.fillText(this.data?.getDisplayableContent() ?? "NA", x, y);
+    painter.writeText(textContent, Point.at(x, y), {
+      font: this.style?.text?.font,
+      color: this.style?.text?.color,
+      baseline: "middle",
+      alignment: textAlign,
+    });
 
     const filterX = this.point.x + this.dimensions.w - padding.right - 6;
     const filterY = this.point.y + padding.top + innerHeight / 2;
 
-    ctx.save();
-    ctx.translate(filterX, filterY);
-    this.headerFilter.draw(ctx);
-    ctx.restore();
-
-    ctx.restore();
+    painter.dangerouslyGetRenderingContext().save();
+    painter.dangerouslyGetRenderingContext().translate(filterX, filterY);
+    this.headerFilter.draw(painter);
+    painter.dangerouslyGetRenderingContext().restore();
   }
 
-  public drawGlobal(ctx: CanvasRenderingContext2D): void {
+  public drawGlobal(painter: Painter): void {
     const resizerX = this.point.x + this.dimensions.w - RESIZER_WIDTH;
 
-    ctx.save();
-    ctx.translate(resizerX, this.point.y);
-    this.headerResizer.draw(ctx);
-    ctx.restore();
+    painter.dangerouslyGetRenderingContext().save();
+    painter.dangerouslyGetRenderingContext().translate(resizerX, this.point.y);
+    this.headerResizer.draw(painter);
+    painter.dangerouslyGetRenderingContext().restore();
   }
 }

--- a/src/table/components/header/table-header.ts
+++ b/src/table/components/header/table-header.ts
@@ -11,6 +11,7 @@ import { Mouse } from "../../../utils/mouse";
 import { Point } from "../../../utils/point";
 import { TableHeaderCell } from "./table-header-cell";
 import { BufferedStream } from "../../../utils/buffered-stream";
+import { Painter } from "../../../utils/painter";
 
 export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
   private cellPool: CellPool<TableHeaderCell>;
@@ -175,7 +176,7 @@ export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
     return undefined;
   }
 
-  private drawCells(ctx: CanvasRenderingContext2D): void {
+  private drawCells(painter: Painter): void {
     this.cellPool.beginFrame();
 
     let isMouseHoveringAnyResizer = false;
@@ -202,7 +203,7 @@ export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
         this.hoveredResizerColumnId = column.columnId;
       }
 
-      cell.draw(ctx);
+      cell.draw(painter);
     }
 
     if (isMouseHoveringAnyResizer) {
@@ -213,10 +214,10 @@ export class TableHeader<TDataRow extends TableRow> extends DrawCanvas {
     }
   }
 
-  public draw(ctx: CanvasRenderingContext2D): void {
-    ctx.translate(-this.snapToDevicePixel(this.camera.x), 0);
+  public draw(painter: Painter): void {
+    painter.translateFromViewport(this.camera.x, 0);
 
-    this.drawCells(ctx);
+    this.drawCells(painter);
   }
 
   private getSortDirection(columnId: string): "ASC" | "DESC" | undefined {

--- a/src/table/components/horizontal-scrollbar.ts
+++ b/src/table/components/horizontal-scrollbar.ts
@@ -3,6 +3,7 @@ import { Camera } from "../../utils/camera";
 import { Dimensions } from "../../utils/dimensions";
 import { DrawCanvas } from "../../utils/draw-canvas";
 import { Mouse } from "../../utils/mouse";
+import { Painter } from "../../utils/painter";
 import { Point } from "../../utils/point";
 import { WorldObject } from "../../utils/world-object";
 
@@ -98,10 +99,9 @@ export class HorizontalScrollbar extends DrawCanvas {
     this.initMouseCallbacks();
   }
 
-  public draw(ctx: CanvasRenderingContext2D): void {
-    ctx.fillStyle = "#fff";
-    ctx.fillRect(0, 0, this.w, this.h);
-    this.thumb.draw(ctx);
+  public draw(painter: Painter): void {
+    painter.drawRect(Point.at(0, 0), Dimensions.of(this.w, this.h), "#fff");
+    this.thumb.draw(painter);
   }
 }
 
@@ -177,10 +177,10 @@ class HorizontalThumb extends WorldObject {
     this.state.isActive = isActive;
   }
 
-  public draw(ctx: CanvasRenderingContext2D): void {
-    ctx.fillStyle =
+  public draw(painter: Painter): void {
+    const color =
       this.state.isHovered || this.state.isActive ? "#6b7280" : "#9ca3af";
-    ctx.fillRect(this.point.x, 0, this.dimensions.w, this.dimensions.h);
+    painter.drawRect(Point.at(this.point.x, 0), this.dimensions, color);
   }
 
   public getBoundingBox(): BoundingBox {

--- a/src/table/components/table-cell.ts
+++ b/src/table/components/table-cell.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_TEXT_ALIGN,
 } from "../../utils/cell-style-defaults";
 import { getPadding } from "../../utils/padding-utils";
+import { Painter } from "../../utils/painter";
 
 export abstract class TableCell extends WorldObject {
   protected data: TableData<unknown> | null = null;
@@ -61,44 +62,30 @@ export abstract class TableCell extends WorldObject {
   }
 
   public abstract drawClipped(
-    ctx: CanvasRenderingContext2D,
+    painter: Painter,
     clippedDimensions: Dimensions,
     padding: Required<Padding>,
   ): void;
 
-  public abstract drawGlobal(ctx: CanvasRenderingContext2D): void;
+  public abstract drawGlobal(painter: Painter): void;
 
-  public draw(ctx: CanvasRenderingContext2D): void {
-    ctx.save();
-
-    ctx.font = this.style?.text?.font ?? DEFAULT_FONT_STRING;
-    ctx.fillStyle = this.style?.text?.color ?? DEFAULT_TEXT_COLOR;
-    ctx.textBaseline = "middle";
-
-    this.drawGlobal(ctx);
+  public draw(painter: Painter): void {
+    this.drawGlobal(painter);
 
     const padding = getPadding(this.style?.padding);
-    const {
-      left: leftPadding,
-      right: rightPadding,
-      top: topPadding,
-      bottom: bottomPadding,
-    } = padding;
 
-    ctx.beginPath();
-    const innerWidth = this.dimensions.w - leftPadding - rightPadding;
-    const innerHeight = this.dimensions.h - topPadding - bottomPadding;
-    ctx.rect(
-      this.point.x + leftPadding,
-      this.point.y + topPadding,
-      innerWidth,
-      innerHeight,
+    const restoreClip = painter.clipArea(this.point, this.dimensions, padding);
+
+    this.drawClipped(
+      painter,
+      new Dimensions(
+        this.dimensions.w - padding.left - padding.right,
+        this.dimensions.h - padding.top - padding.bottom,
+      ),
+      padding,
     );
-    ctx.clip();
 
-    this.drawClipped(ctx, new Dimensions(innerWidth, innerHeight), padding);
-
-    ctx.restore();
+    restoreClip();
   }
 
   protected getAlignment(innerWidth: number): {

--- a/src/table/components/vertical-scrollbar.ts
+++ b/src/table/components/vertical-scrollbar.ts
@@ -3,6 +3,7 @@ import { Camera } from "../../utils/camera";
 import { Dimensions } from "../../utils/dimensions";
 import { DrawCanvas } from "../../utils/draw-canvas";
 import { Mouse } from "../../utils/mouse";
+import { Painter } from "../../utils/painter";
 import { Point } from "../../utils/point";
 import { WorldObject } from "../../utils/world-object";
 
@@ -93,10 +94,9 @@ export class VerticalScrollbar extends DrawCanvas {
     this.initMouseCallbacks();
   }
 
-  public draw(ctx: CanvasRenderingContext2D): void {
-    ctx.fillStyle = "#fff";
-    ctx.fillRect(0, 0, this.w, this.h);
-    this.thumb.draw(ctx);
+  public draw(painter: Painter): void {
+    painter.drawRect(Point.at(0, 0), Dimensions.of(this.w, this.h), "#fff");
+    this.thumb.draw(painter);
   }
 }
 
@@ -175,10 +175,10 @@ class VerticalThumb extends WorldObject {
     this.state.isActive = isActive;
   }
 
-  public draw(ctx: CanvasRenderingContext2D): void {
-    ctx.fillStyle =
+  public draw(painter: Painter): void {
+    const color =
       this.state.isHovered || this.state.isActive ? "#6b7280" : "#9ca3af";
-    ctx.fillRect(0, this.point.y, this.dimensions.w, this.dimensions.h);
+    painter.drawRect(Point.at(0, this.point.y), this.dimensions, color);
   }
 
   public getBoundingBox(): BoundingBox {

--- a/src/utils/dimensions.ts
+++ b/src/utils/dimensions.ts
@@ -3,4 +3,8 @@ export class Dimensions {
     public w: number = 0,
     public h: number = 0,
   ) {}
+
+  public static of(w: number, h: number): Dimensions {
+    return new Dimensions(w, h);
+  }
 }

--- a/src/utils/draw-canvas.ts
+++ b/src/utils/draw-canvas.ts
@@ -3,26 +3,27 @@ import { Closeable } from "./closeable";
 import { Drawable } from "./drawable";
 import { Canvas } from "./canvas";
 import { Dimensions } from "./dimensions";
+import { Painter } from "./painter";
 
 export abstract class DrawCanvas extends Canvas implements Closeable, Drawable {
-  private ctx: CanvasRenderingContext2D;
+  private readonly painter: Painter;
   private drawQueue$: ReplaySubject<void>;
-  protected dpr: number = 1;
 
   constructor(dimensions: Dimensions) {
     super(dimensions);
 
-    this.ctx = this.canvas.getContext("2d")!;
+    this.painter = new Painter(this.canvas.getContext("2d")!);
     this.drawQueue$ = new ReplaySubject(1);
   }
 
   public resize(w: number, h: number, dpr: number = 1): void {
-    this.dpr = dpr;
     this.canvas.width = Math.round(w * dpr);
     this.canvas.height = Math.round(h * dpr);
     this.resizeCanvas(w, h);
 
-    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    this.painter
+      .dangerouslyGetRenderingContext()
+      .setTransform(dpr, 0, 0, dpr, 0, 0);
     this.requestRedraw();
   }
 
@@ -34,21 +35,19 @@ export abstract class DrawCanvas extends Canvas implements Closeable, Drawable {
     this.drawQueue$.next();
   }
 
-  public abstract draw(ctx: CanvasRenderingContext2D): void;
+  public abstract draw(painter: Painter): void;
 
   public _drawImpl(): void {
-    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.painter
+      .dangerouslyGetRenderingContext()
+      .clearRect(0, 0, this.canvas.width, this.canvas.height);
 
-    this.ctx.save();
-    this.draw(this.ctx);
-    this.ctx.restore();
+    this.painter.dangerouslyGetRenderingContext().save();
+    this.draw(this.painter);
+    this.painter.dangerouslyGetRenderingContext().restore();
   }
 
   public close(): void {
     this.drawQueue$.complete();
-  }
-
-  protected snapToDevicePixel(value: number): number {
-    return Math.round(value * this.dpr) / this.dpr;
   }
 }

--- a/src/utils/drawable.ts
+++ b/src/utils/drawable.ts
@@ -1,3 +1,5 @@
+import { Painter } from "./painter";
+
 export interface Drawable {
-  draw(ctx: CanvasRenderingContext2D): void;
+  draw(ctx: Painter): void;
 }

--- a/src/utils/painter.ts
+++ b/src/utils/painter.ts
@@ -1,0 +1,83 @@
+import { Padding } from "../types/table-cell-types";
+import { DEFAULT_FONT_STRING, DEFAULT_TEXT_COLOR } from "./cell-style-defaults";
+import { Dimensions } from "./dimensions";
+import { Point } from "./point";
+
+type RestoreFunction = () => void;
+
+export class Painter {
+  private ctx: CanvasRenderingContext2D;
+
+  constructor(ctx: CanvasRenderingContext2D) {
+    this.ctx = ctx;
+  }
+
+  public dangerouslyGetRenderingContext(): CanvasRenderingContext2D {
+    return this.ctx;
+  }
+
+  public translateFromViewport(x: number, y: number): void {
+    this.ctx.translate(
+      -Point.snapToDevicePixel(x),
+      -Point.snapToDevicePixel(y),
+    );
+  }
+
+  public drawRect(point: Point, dimensions: Dimensions, color: string): void {
+    this.ctx.save();
+
+    this.ctx.fillStyle = color;
+
+    const x1 = Point.snapToDevicePixel(point.x);
+    const x2 = Point.snapToDevicePixel(point.x + dimensions.w);
+    const y1 = Point.snapToDevicePixel(point.y);
+    const y2 = Point.snapToDevicePixel(point.y + dimensions.h);
+
+    this.ctx.fillRect(x1, y1, x2 - x1, y2 - y1);
+
+    this.ctx.restore();
+  }
+
+  public writeText(
+    text: string,
+    point: Point,
+    opts?: Partial<{
+      font: string;
+      color: string;
+      baseline: CanvasTextBaseline;
+      alignment: CanvasTextAlign;
+    }>,
+  ): void {
+    this.ctx.save();
+
+    this.ctx.textAlign = opts?.alignment ?? "right";
+    this.ctx.font = opts?.font ?? DEFAULT_FONT_STRING;
+    this.ctx.fillStyle = opts?.color ?? DEFAULT_TEXT_COLOR;
+    this.ctx.textBaseline = opts?.baseline ?? "middle";
+
+    this.ctx.fillText(text, point.x, point.y);
+
+    this.ctx.restore();
+  }
+
+  public clipArea(
+    point: Point,
+    dimensions: Dimensions,
+    padding: Required<Padding>,
+  ): RestoreFunction {
+    this.ctx.save();
+
+    this.ctx.beginPath();
+    const innerWidth = dimensions.w - padding.left - padding.right;
+    const innerHeight = dimensions.h - padding.top - padding.bottom;
+    this.ctx.rect(
+      point.x + padding.left,
+      point.y + padding.top,
+      innerWidth,
+      innerHeight,
+    );
+    this.ctx.clip();
+
+    return () => this.ctx.restore();
+  }
+}

--- a/src/utils/point.ts
+++ b/src/utils/point.ts
@@ -4,6 +4,10 @@ export class Point {
     public y: number = 0,
   ) {}
 
+  public static at(x: number, y: number): Point {
+    return new Point(x, y);
+  }
+
   public equals(other: Point): boolean {
     return this.x === other.x && this.y === other.y;
   }
@@ -19,5 +23,11 @@ export class Point {
 
   public static clone(other: Point): Point {
     return new Point(other.x, other.y);
+  }
+
+  public static snapToDevicePixel(value: number): number {
+    return (
+      Math.round(value * window.devicePixelRatio) / window.devicePixelRatio
+    );
   }
 }

--- a/src/utils/world-object.ts
+++ b/src/utils/world-object.ts
@@ -1,6 +1,7 @@
 import { BoundingBox } from "./bounding-box";
 import { Drawable } from "./drawable";
 import { ObjectState } from "./object-state";
+import { Painter } from "./painter";
 import { Point } from "./point";
 
 export abstract class WorldObject implements Drawable {
@@ -11,7 +12,7 @@ export abstract class WorldObject implements Drawable {
     if (point) this.point = point;
   }
 
-  public abstract draw(ctx: CanvasRenderingContext2D): void;
+  public abstract draw(ctx: Painter): void;
 
   public abstract getBoundingBox(): BoundingBox;
 }


### PR DESCRIPTION
This PR adds a delegate painter class to handle drawing common world objects on pixel-aligned coordinate points. A `dangerouslyGetRenderingContext` method exists for backwards compatibility and unimplemented drawings.