### PR TITLE
clean up barrel exports and improve typing for custom render cell

### DIFF
--- a/sample/vite/src/pages/L2/utils/p50RenderCell.ts
+++ b/sample/vite/src/pages/L2/utils/p50RenderCell.ts
@@ -1,17 +1,22 @@
-import { Dimensions, Painter, TableCell } from "../../../../../../dist";
+import {
+  Dimensions,
+  Painter,
+  Point,
+  TableCell,
+  type Padding,
+} from "../../../../../../dist";
 
 export class P50RenderCell extends TableCell {
   drawClipped(
     painter: Painter,
     clippedDimensions: Dimensions,
-    padding: Required<{
-      top?: number;
-      bottom?: number;
-      left?: number;
-      right?: number;
-    }>,
+    padding: Required<Padding>,
   ): void {
-    void this.drawClipped;
+    painter.drawRect(
+      Point.at(this.point.x + padding.left, this.point.y + padding.top),
+      clippedDimensions,
+      "pink",
+    );
   }
 
   drawGlobal(painter: Painter): void {

--- a/sample/vite/src/pages/L2/utils/tableConfig.ts
+++ b/sample/vite/src/pages/L2/utils/tableConfig.ts
@@ -72,7 +72,7 @@ const columns: Array<TableColumnDef<StatsRow, number>> = [
     autoResize: false,
     placeholderAccessorFn: (row) => row.placeholders.p50,
     cellData: () => new NumberTableData(),
-    renderCell: () => new P50RenderCell(),
+    renderCell: (style) => new P50RenderCell(style),
   },
   {
     columnId: "p75",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,5 @@
 export { createTable } from "./table/table";
 export type { Table } from "./table/table";
-export type {
-  TableConfig,
-  TableColumnDef,
-  TableOptions,
-  TableRow,
-  TableSourceObservable,
-  TableSourceData,
-} from "./types/table-config";
-export { StringTableData } from "./utils/string-table-data";
-export { TableData } from "./utils/table-data";
 export { TableCell } from "./table/components/table-cell";
-export { Dimensions } from "./utils/dimensions";
-export { Painter } from "./utils/painter";
+export * from "./types/index";
+export * from "./utils/index";

--- a/src/table/components/body/table-body.ts
+++ b/src/table/components/body/table-body.ts
@@ -325,7 +325,15 @@ function extractRenderCellFactories<TDataRow extends TableRow>(
   const defaultTableBodyCellFactory = () => new TableBodyCell(tableCellStyles);
   const accumulator: Record<string, () => TableCell> = {};
   const res = columnDefs.reduce((acc, curr) => {
-    acc[curr.columnId] = curr.renderCell ?? defaultTableBodyCellFactory;
+    const renderCellFactory = curr.renderCell;
+    if (renderCellFactory) {
+      const customTableBodyCellFactory = () => {
+        return renderCellFactory(tableCellStyles);
+      };
+      acc[curr.columnId] = customTableBodyCellFactory;
+    } else {
+      acc[curr.columnId] = defaultTableBodyCellFactory;
+    }
     return acc;
   }, accumulator);
   return res;

--- a/src/table/components/table-cell.ts
+++ b/src/table/components/table-cell.ts
@@ -3,11 +3,7 @@ import { Dimensions } from "../../utils/dimensions";
 import { WorldObject } from "../../utils/world-object";
 import { TableData } from "../../utils/table-data";
 import { BoundingBox } from "../../utils/bounding-box";
-import {
-  DEFAULT_FONT_STRING,
-  DEFAULT_TEXT_COLOR,
-  DEFAULT_TEXT_ALIGN,
-} from "../../utils/cell-style-defaults";
+import { DEFAULT_TEXT_ALIGN } from "../../utils/cell-style-defaults";
 import { getPadding } from "../../utils/padding-utils";
 import { Painter } from "../../utils/painter";
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,15 @@
+export {
+  TableCellFontStyling,
+  TableCellStyles,
+  TableCellHoverStyles,
+  Padding,
+} from "./table-cell-types";
+export {
+  TableOptions,
+  TableConfig,
+  TableStyles,
+  TableColumnDef,
+  TableRow,
+  TableSourceObservable,
+  TableSourceData,
+} from "./table-config";

--- a/src/types/table-config.ts
+++ b/src/types/table-config.ts
@@ -38,8 +38,12 @@ export type TableColumnDef<TDataRow extends TableRow, TValue = unknown> = {
   autoResize: boolean;
   placeholderAccessorFn: (row: TDataRow) => TValue;
   cellData: () => TableData<TValue>;
-  renderCell?: () => TableCell;
+  renderCell?: RenderCellFactory;
 };
+
+export type RenderCellFactory = (
+  ...args: ConstructorParameters<typeof TableCell>
+) => TableCell;
 
 export type TableRow = {
   rowId: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,5 @@
+export { Point } from "./point";
+export { Dimensions } from "./dimensions";
+export { TableData } from "./table-data";
+export { StringTableData } from "./string-table-data";
+export { Painter } from "./painter";


### PR DESCRIPTION
This PR organizes the barrel exports by adding two new index.ts files in subdirectories. It also improves the typing of the render cell factory by taking in a style parameter and injecting the value at runtime via a closure. The example code is also updated to reflect this.