### PR TITLE
import web worker source as blob to simplify consumer DX

### DIFF
--- a/.changeset/vast-ads-learn.md
+++ b/.changeset/vast-ads-learn.md
@@ -1,0 +1,5 @@
+---
+"@dongjiy/l2-table": patch
+---
+
+import and instantiate table layout worker as blob

--- a/packages/core/src/table/table-worker.ts
+++ b/packages/core/src/table/table-worker.ts
@@ -3,6 +3,7 @@ import {
   WorkerRequest,
   WorkerResponse,
 } from "../types/table-worker-types";
+import workerSource from "../worker/entrypoint-inline";
 
 export class TableWorker {
   private worker: Worker;
@@ -10,8 +11,12 @@ export class TableWorker {
 
   constructor() {
     this.listeners = new Map();
+
+    const blob = new Blob([workerSource], { type: "application/javascript" });
+    const blobUrl = URL.createObjectURL(blob);
+
     this.worker = new Worker(
-      new URL("./worker/entrypoint.js", import.meta.url), // this is relative to dist
+      blobUrl,
       {
         type: "module",
       },

--- a/packages/core/src/worker/entrypoint-inline.ts
+++ b/packages/core/src/worker/entrypoint-inline.ts
@@ -1,0 +1,2 @@
+// This file is replaced by the inline-worker plugin
+export default "";

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,11 +1,31 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/worker/entrypoint.ts"],
+  entry: ["src/index.ts"],
   format: ["esm", "iife"],
   dts: true,
   outDir: "dist",
   sourcemap: true,
   clean: true,
   globalName: "L2Table",
+  esbuildPlugins: [
+    {
+      name: "inline-worker",
+      setup(build) {
+        build.onLoad({ filter: /src\/worker\/entrypoint-inline\.ts$/ }, async (args) => {
+          const result = await build.esbuild.build({
+            entryPoints: [args.path.replace("entrypoint-inline", "entrypoint")],
+            bundle: true,
+            write: false,
+            format: "esm",
+          });
+          const code = result.outputFiles[0].text;
+          return {
+            contents: `export default ${JSON.stringify(code)}`,
+            loader: "js",
+          };
+        });
+      },
+    },
+  ]
 });

--- a/sample/vite/vite.config.ts
+++ b/sample/vite/vite.config.ts
@@ -5,20 +5,11 @@ import path from "path";
 export default defineConfig({
   plugins: [react()],
 
-  optimizeDeps: {
-    exclude: ["l2-table"],
-  },
-
   server: {
     fs: {
       allow: [
         path.resolve(__dirname), // my-react-app
-        path.resolve(__dirname, "../../"), // l2-table repo root
       ],
     },
-  },
-
-  resolve: {
-    preserveSymlinks: true,
   },
 });


### PR DESCRIPTION
This PR adds a tsup config to build and export the worker entrypoint file as a blob within the core library. This prevents needing to handle interactions with the consumer bundler. 